### PR TITLE
Return previous error and exception handlers

### DIFF
--- a/src/System/System.php
+++ b/src/System/System.php
@@ -20,12 +20,12 @@ class System implements SystemProvider
 
     public function setErrorHandler(callable $handler)
     {
-        set_error_handler($handler);
+        return set_error_handler($handler);
     }
 
     public function setExceptionHandler(callable $handler)
     {
-        set_exception_handler($handler);
+        return set_exception_handler($handler);
     }
 
     public function registerShutdownFunction(callable $handler)


### PR DESCRIPTION
Previous error and exception handlers are thrown away, which conflicts with the intent of `ErrorHandler::install()`.