### PR TITLE
Feature - JSON renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ When you use the bundled debug handler, it tries to choose an appropiate output 
 
 - The [CLI renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugCliRenderer.php) when `php_sapi_name() === "cli`. [Example output](https://slashtrace.com/demo-cli.png).
 - The [plain text renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugTextRenderer.php), for AJAX requests (requests with the `X-Requested-With: XMLHttpRequest` header). [Example output](https://slashtrace.com/demo-ajax.png).
-- The [JSON renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugJsonRenderer.php), for requests with the `Accept: application/json` header. [Example output](https://slashtrace.com/demo.json).
+- The [JSON renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugJsonRenderer.php), for requests with the `Accept: application/json` header. This takes precedence over the text renderer, in case both headers are present. [Example output](https://slashtrace.com/demo.json).
 - The [Web renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugWebRenderer.php), for all other requests. [Example output](https://slashtrace.com/demo.php).
 
 Alternatively, you can force the debug handler to use a particular renderer:

--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 
 ---
 
-[![Screenshot](https://i.imgur.com/pt4jlYX.png)](https://slashtrace.com/demo.php)
+[![Screenshot](https://slashtrace.com/demo.png)](https://slashtrace.com/demo.php)
 
 ---
 
-SlashTrace is, at its core, an error and exception handler. You hook it into your error handling routine (or let it set itself up to catch all errors and exceptions), and it captures and displays a lot of nice information about your errors. It does this for normal browser requests, but also for [AJAX](https://i.imgur.com/BnvCp4N.png) and the [CLI](https://i.imgur.com/GA7tS0T.png).
+SlashTrace is, at its core, an error and exception handler. You hook it into your error handling routine (or let it set itself up to catch all errors and exceptions), and it captures and displays a lot of nice information about your errors. It does this for normal browser requests, but also for [AJAX](https://slashtrace.com/demo-ajax.png), the [CLI](https://slashtrace.com/demo-cli.png), and [JSON APIs](https://slashtrace.com/demo.json).
 
 When you're done with local debugging, you can configure SlashTrace to send errors to dedicated error reporting services, like [Sentry](https://sentry.io/), [Raygun](https://raygun.com/), and [Bugsnag](https://www.bugsnag.com/).
 
@@ -114,6 +114,25 @@ Tracker docs:
 - [Raygun - Version numbers](https://raygun.com/docs/languages/php#php-version-number)
 - Bugsnag - The release version cannot be explicitly set per event. Read the [Bugsnag docs](https://docs.bugsnag.com/platforms/php/other/#tracking-releases) for more details.
 
+## Debug renderers
 
+When you use the bundled debug handler, it tries to choose an appropiate output renderer based on the environment in which it's running, like this:
+
+- The [CLI renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugCliRenderer.php) when `php_sapi_name() === "cli`. [Example output](https://slashtrace.com/demo-cli.png).
+- The [plain text renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugTextRenderer.php), for AJAX requests (requests with the `X-Requested-With: XMLHttpRequest` header). [Example output](https://slashtrace.com/demo-ajax.png).
+- The [JSON renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugJsonRenderer.php), for requests with the `Accept: application/json` header. [Example output](https://slashtrace.com/demo.json).
+- The [Web renderer](https://github.com/slashtrace/slashtrace/blob/master/src/DebugRenderer/DebugWebRenderer.php), for all other requests. [Example output](https://slashtrace.com/demo.php).
+
+Alternatively, you can force the debug handler to use a particular renderer:
+
+```PHP
+use SlashTrace\EventHandler\DebugHandler;
+use SlashTrace\DebugRenderer\DebugJsonRenderer;
+
+$handler = new DebugHandler();
+$handler->setRenderer(new DebugJsonRenderer());
+
+$slashtrace->addHandler($handler);
+```
 
 

--- a/src/Context/Breadcrumbs.php
+++ b/src/Context/Breadcrumbs.php
@@ -2,11 +2,12 @@
 
 namespace SlashTrace\Context;
 
+use JsonSerializable;
 use SlashTrace\Context\Breadcrumbs\Breadcrumb;
 use SlashTrace\System\SystemProvider;
 use DateTime;
 
-class Breadcrumbs
+class Breadcrumbs implements JsonSerializable
 {
     const MAX_SIZE = 25;
 
@@ -76,5 +77,10 @@ class Breadcrumbs
     public function clear()
     {
         $this->crumbs = [];
+    }
+
+    public function jsonSerialize()
+    {
+        return $this->crumbs;
     }
 }

--- a/src/Context/Breadcrumbs/Breadcrumb.php
+++ b/src/Context/Breadcrumbs/Breadcrumb.php
@@ -3,8 +3,9 @@
 namespace SlashTrace\Context\Breadcrumbs;
 
 use DateTime;
+use JsonSerializable;
 
-class Breadcrumb
+class Breadcrumb implements JsonSerializable
 {
     /** @var string */
     private $title;
@@ -49,5 +50,14 @@ class Breadcrumb
     public function getDateTime()
     {
         return $this->dateTime;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            "title" => $this->getTitle(),
+            "data"  => $this->getData(),
+            "time"  => $this->getDateTime()->format(DATE_ATOM),
+        ];
     }
 }

--- a/src/Context/EventContext.php
+++ b/src/Context/EventContext.php
@@ -3,9 +3,10 @@
 namespace SlashTrace\Context;
 
 use Exception;
+use JsonSerializable;
 use SlashTrace\Http\Request;
 
-class EventContext
+class EventContext implements JsonSerializable
 {
     /** @var string */
     private $release;
@@ -127,5 +128,17 @@ class EventContext
             return true;
         }
         return !is_null($this->getRelease()) || !is_null($this->getUser());
+    }
+
+    public function jsonSerialize()
+    {
+        return array_filter([
+            "request"          => $this->getHTTPRequest(),
+            "server"           => $this->getServer(),
+            "user"             => $this->getUser(),
+            "breadcrumbs"      => $this->getBreadcrumbs(),
+            "release"          => $this->getRelease(),
+            "application_path" => $this->getApplicationPath(),
+        ]);
     }
 }

--- a/src/Context/User.php
+++ b/src/Context/User.php
@@ -3,8 +3,9 @@
 namespace SlashTrace\Context;
 
 use InvalidArgumentException;
+use JsonSerializable;
 
-class User
+class User implements JsonSerializable
 {
     /** @var string */
     private $id;
@@ -64,5 +65,14 @@ class User
     public function setName($name)
     {
         $this->name = $name;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_filter([
+            "id"    => $this->getId(),
+            "email" => $this->getEmail(),
+            "name"  => $this->getName(),
+        ]);
     }
 }

--- a/src/DebugRenderer/DebugJsonRenderer.php
+++ b/src/DebugRenderer/DebugJsonRenderer.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace SlashTrace\DebugRenderer;
+
+use SlashTrace\Event;
+
+class DebugJsonRenderer implements DebugRenderer
+{
+    public function render(Event $event)
+    {
+        // TODO: Implement render() method
+    }
+}

--- a/src/DebugRenderer/DebugJsonRenderer.php
+++ b/src/DebugRenderer/DebugJsonRenderer.php
@@ -3,11 +3,19 @@
 namespace SlashTrace\DebugRenderer;
 
 use SlashTrace\Event;
+use SlashTrace\System\HasSystemProvider;
 
 class DebugJsonRenderer implements DebugRenderer
 {
+    use HasSystemProvider;
+
     public function render(Event $event)
     {
-        // TODO: Implement render() method
+        $this->getSystem()->output(
+            json_encode(array_merge(
+                ["success" => false],
+                $event->jsonSerialize()
+            ))
+        );
     }
 }

--- a/src/Event.php
+++ b/src/Event.php
@@ -4,10 +4,10 @@ namespace SlashTrace;
 
 use SlashTrace\Context\EventContext;
 use SlashTrace\Exception\ExceptionData;
+use JsonSerializable;
 
-class Event
+class Event implements JsonSerializable
 {
-
     /** @var string */
     private $level;
 
@@ -59,4 +59,12 @@ class Event
         $this->context = $context;
     }
 
+    public function jsonSerialize()
+    {
+        return [
+            "level"   => $this->getLevel(),
+            "errors"  => $this->getExceptions(),
+            "context" => $this->getContext(),
+        ];
+    }
 }

--- a/src/EventHandler/DebugHandler.php
+++ b/src/EventHandler/DebugHandler.php
@@ -5,6 +5,7 @@ namespace SlashTrace\EventHandler;
 use SlashTrace\Context\Breadcrumbs;
 use SlashTrace\Context\EventContext;
 use SlashTrace\Context\User;
+use SlashTrace\DebugRenderer\DebugJsonRenderer;
 use SlashTrace\DebugRenderer\DebugRenderer;
 use SlashTrace\DebugRenderer\DebugCliRenderer;
 use SlashTrace\DebugRenderer\DebugWebRenderer;
@@ -75,6 +76,10 @@ class DebugHandler implements EventHandler
         }
 
         $request = $system->getHttpRequest();
+        if ($request->getHeader("Accept") === "application/json") {
+            return new DebugJsonRenderer();
+        }
+
         if ($request->isXhr()) {
             return new DebugTextRenderer();
         }

--- a/src/Exception/ExceptionData.php
+++ b/src/Exception/ExceptionData.php
@@ -2,9 +2,10 @@
 
 namespace SlashTrace\Exception;
 
+use JsonSerializable;
 use SlashTrace\StackTrace\StackFrame;
 
-class ExceptionData
+class ExceptionData implements JsonSerializable
 {
     /** @var string */
     private $message;
@@ -49,5 +50,14 @@ class ExceptionData
     public function setStackTrace(array $stackTrace)
     {
         $this->stackTrace = $stackTrace;
+    }
+
+    public function jsonSerialize()
+    {
+        return array_filter([
+            "type"       => $this->getType(),
+            "message"    => $this->getMessage(),
+            "stacktrace" => $this->getStackTrace(),
+        ]);
     }
 }

--- a/src/Formatter/StackFrameCallTextFormatter.php
+++ b/src/Formatter/StackFrameCallTextFormatter.php
@@ -4,7 +4,6 @@ namespace SlashTrace\Formatter;
 
 class StackFrameCallTextFormatter extends StackFrameCallFormatter
 {
-
     /** @var StackTraceTagFormatter */
     private $tagFormatter;
 
@@ -39,5 +38,4 @@ class StackFrameCallTextFormatter extends StackFrameCallFormatter
         }
         return $this->tagFormatter->format($input, $tag);
     }
-
 }

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -62,7 +62,7 @@ class Request
         return implode("-", $parts);
     }
 
-    private function getHeader($header)
+    public function getHeader($header)
     {
         $headers = $this->getHeaders();
         return isset($headers[$header]) ? $headers[$header] : null;

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -2,7 +2,9 @@
 
 namespace SlashTrace\Http;
 
-class Request
+use JsonSerializable;
+
+class Request implements JsonSerializable
 {
     protected $headers = [];
 
@@ -137,5 +139,17 @@ class Request
             }
         }
         return null;
+    }
+
+    public function jsonSerialize()
+    {
+        return [
+            "url"     => $this->getUrl(),
+            "headers" => $this->getHeaders(),
+            "get"     => $this->getGetData(),
+            "post"    => $this->getPostData(),
+            "cookies" => $this->getCookies(),
+            "ip"      => $this->getIP(),
+        ];
     }
 }

--- a/src/StackTrace/StackFrame.php
+++ b/src/StackTrace/StackFrame.php
@@ -2,9 +2,12 @@
 
 namespace SlashTrace\StackTrace;
 
-class StackFrame
-{
+use JsonSerializable;
+use SlashTrace\Formatter\StackFrameCallTextFormatter;
+use SlashTrace\Serializer\Serializer;
 
+class StackFrame implements JsonSerializable
+{
     const TYPE_METHOD = "->";
     const TYPE_STATIC = "::";
     const TYPE_FUNCTION = "";
@@ -110,4 +113,17 @@ class StackFrame
         return ltrim(substr($path, strlen($rootPath)), "/\\");
     }
 
+    public function jsonSerialize()
+    {
+        $serializer = new Serializer();
+        $callFormatter = new StackFrameCallTextFormatter();
+        return array_filter([
+            "at"        => $callFormatter->format($this),
+            "file"      => $this->getFile(),
+            "line"      => $this->getLine(),
+            "arguments" => array_map(function ($argument) use ($serializer) {
+                return $serializer->serialize($argument);
+            }, $this->getArguments()),
+        ]);
+    }
 }

--- a/tests/DebugRenderer/DebugJsonRendererTest.php
+++ b/tests/DebugRenderer/DebugJsonRendererTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace SlashTrace\Tests\DebugRenderer;
+
+use SlashTrace\DebugRenderer\DebugJsonRenderer;
+use SlashTrace\Event;
+use SlashTrace\Tests\Doubles\System\MockSystemProvider;
+use SlashTrace\Tests\TestCase;
+
+class DebugJsonRendererTest extends TestCase
+{
+    /** @var DebugJsonRenderer */
+    private $renderer;
+
+    /** @var MockSystemProvider */
+    private $system;
+
+    protected function setUp()
+    {
+        parent::setUp();
+
+        $this->system = new MockSystemProvider();
+
+        $this->renderer = new DebugJsonRenderer();
+        $this->renderer->setSystem($this->system);
+    }
+
+    public function testOutput()
+    {
+        $event = $this->createMock(Event::class);
+        $event->expects($this->once())
+            ->method("jsonSerialize")
+            ->willReturn(["foo" => "bar"]);
+
+        /** @noinspection PhpParamsInspection */
+        $this->renderer->render($event);
+
+        $this->assertEquals(
+            json_encode([
+                "success" => false,
+                "foo"     => "bar",
+            ]),
+            $this->system->getOutput()[0]
+        );
+    }
+}

--- a/tests/EventHandler/DebugHandlerTest.php
+++ b/tests/EventHandler/DebugHandlerTest.php
@@ -4,6 +4,7 @@ namespace SlashTrace\Tests\EventHandler;
 
 use SlashTrace\Context\EventContext;
 use SlashTrace\Context\User;
+use SlashTrace\DebugRenderer\DebugJsonRenderer;
 use SlashTrace\DebugRenderer\DebugRenderer;
 use SlashTrace\Http\Request;
 use SlashTrace\DebugRenderer\DebugCliRenderer;
@@ -93,6 +94,18 @@ class DebugHandlerTest extends TestCase
         $this->system->setIsWeb($request);
 
         $this->assertInstanceOf(DebugTextRenderer::class, $this->handler->getRenderer());
+    }
+
+    public function testRendererSelectionWhenJsonRequest()
+    {
+        $request = $this->createMock(Request::class);
+        $request->expects($this->once())
+            ->method("getHeader")
+            ->with("Accept")
+            ->willReturn("application/json");
+
+        $this->system->setIsWeb($request);
+        $this->assertInstanceOf(DebugJsonRenderer::class, $this->handler->getRenderer());
     }
 
     public function testCanSetRenderer()

--- a/tests/EventTest.php
+++ b/tests/EventTest.php
@@ -1,0 +1,113 @@
+<?php
+
+namespace SlashTrace\Tests;
+
+use SlashTrace\Context\EventContext;
+use SlashTrace\Context\User;
+use SlashTrace\Event;
+use SlashTrace\Exception\ExceptionData;
+use SlashTrace\Level;
+use SlashTrace\StackTrace\StackFrame;
+
+use SlashTrace\Tests\Doubles\Context\MockRequest;
+use SlashTrace\Tests\Fixtures\BreadcrumbsFixture;
+
+use DateTime;
+use ErrorException;
+
+/**
+ * @covers \SlashTrace\Event
+ */
+class EventTest extends TestCase
+{
+    /**
+     * @covers \SlashTrace\Event::jsonSerialize
+     * @covers \SlashTrace\Exception\ExceptionData::jsonSerialize
+     * @covers \SlashTrace\StackTrace\StackFrame::jsonSerialize
+     * @covers \SlashTrace\Context\EventContext::jsonSerialize
+     * @covers \SlashTrace\Http\Request::jsonSerialize
+     * @covers \SlashTrace\Context\Breadcrumbs::jsonSerialize
+     * @covers \SlashTrace\Context\Breadcrumbs\Breadcrumb::jsonSerialize
+     * @covers \SlashTrace\Context\User::jsonSerialize
+     */
+    public function testJsonSerialize()
+    {
+        $event = new Event();
+        $event->setLevel(Level::ERROR);
+        $event->addException($this->mockException());
+        $event->setContext($this->mockContext());
+
+        $this->assertEquals(
+            file_get_contents(__DIR__ . "/Fixtures/resources/event.json"),
+            json_encode($event, JSON_PRETTY_PRINT)
+        );
+    }
+
+    private function mockException()
+    {
+        $exception = new ExceptionData();
+        $exception->setType(ErrorException::class);
+        $exception->setMessage("Something went wrong!");
+
+        $exception->setStackTrace([$this->mockStackFrane()]);
+        return $exception;
+    }
+
+    private function mockStackFrane()
+    {
+        $frame = new StackFrame();
+        $frame->setFile("/foo/bar.php");
+        $frame->setLine(100);
+        $frame->setClassName("SlashTrace\\Test");
+        $frame->setFunctionName("test");
+        $frame->setType(StackFrame::TYPE_METHOD);
+        $frame->setArguments([1, 2, 3]);
+
+        return $frame;
+    }
+
+    private function mockContext()
+    {
+        $context = new EventContext();
+
+        $context->setHttpRequest($this->mockRequest());
+        $context->setServer(["foo" => "bar"]);
+        $context->setBreadcrumbs($this->mockBreadcrumbs());
+        $context->setApplicationPath("/var/www");
+        $context->setRelease("1.0.0");
+        $context->setUser($this->mockUser());
+
+        return $context;
+    }
+
+    private function mockRequest()
+    {
+        $request = new MockRequest();
+        $request->setURL("https://example.com");
+        $request->setHeaders(["Accept" => "application/json"]);
+        $request->setCookies(["PHPSESSID" => "foo"]);
+        $request->setPostData(["foo" => "bar"]);
+        $request->setIP("123.123.123.123");
+
+        return $request;
+    }
+
+    private function mockBreadcrumbs()
+    {
+        $breadcrumbs = new BreadcrumbsFixture();
+        $breadcrumbs->setTime(new DateTime("2018-10-06T13:18:30+00:00"));
+        $breadcrumbs->record("Foo", ["foo" => "bar"]);
+
+        return $breadcrumbs;
+    }
+
+    private function mockUser()
+    {
+        $user = new User();
+        $user->setId(123);
+        $user->setName("John Doe");
+        $user->setEmail("john.doe@example.com");
+
+        return $user;
+    }
+}

--- a/tests/Fixtures/resources/event.json
+++ b/tests/Fixtures/resources/event.json
@@ -1,0 +1,56 @@
+{
+    "level": "error",
+    "errors": [
+        {
+            "type": "ErrorException",
+            "message": "Something went wrong!",
+            "stacktrace": [
+                {
+                    "at": "SlashTrace\\Test->test(1, 2, 3)",
+                    "file": "\/foo\/bar.php",
+                    "line": 100,
+                    "arguments": [
+                        1,
+                        2,
+                        3
+                    ]
+                }
+            ]
+        }
+    ],
+    "context": {
+        "request": {
+            "url": "https:\/\/example.com",
+            "headers": {
+                "Accept": "application\/json"
+            },
+            "get": [],
+            "post": {
+                "foo": "bar"
+            },
+            "cookies": {
+                "PHPSESSID": "foo"
+            },
+            "ip": "123.123.123.123"
+        },
+        "server": {
+            "foo": "bar"
+        },
+        "user": {
+            "id": 123,
+            "email": "john.doe@example.com",
+            "name": "John Doe"
+        },
+        "breadcrumbs": [
+            {
+                "title": "Foo",
+                "data": {
+                    "foo": "bar"
+                },
+                "time": "2018-10-06T13:19:00+00:00"
+            }
+        ],
+        "release": "1.0.0",
+        "application_path": "\/var\/www"
+    }
+}

--- a/tests/Formatter/StackFrameCallTextFormatterTest.php
+++ b/tests/Formatter/StackFrameCallTextFormatterTest.php
@@ -62,7 +62,7 @@ class StackFrameCallTextFormatterTest extends StackFrameCallFormatterTestCase
         $this->frame->setArguments([
             "/var/www/index.php",
             new stdClass,
-            [1, 2, 3]
+            [1, 2, 3],
         ]);
 
         $this->assertFormat('test("/var/www/index.php", Object[stdClass], array[3])');
@@ -71,9 +71,9 @@ class StackFrameCallTextFormatterTest extends StackFrameCallFormatterTestCase
     public function testTagFormatterIsUsed()
     {
         $this->tagFormatter->setTags([
-            StackTraceTagFormatter::TAG_CLASS => "class",
+            StackTraceTagFormatter::TAG_CLASS    => "class",
             StackTraceTagFormatter::TAG_FUNCTION => "function",
-            StackTraceTagFormatter::TAG_ARGUMENT => "argument"
+            StackTraceTagFormatter::TAG_ARGUMENT => "argument",
         ]);
 
         $this->frame->setClassName("TestNamespace\\TestClass");
@@ -82,5 +82,17 @@ class StackFrameCallTextFormatterTest extends StackFrameCallFormatterTestCase
         $this->frame->setArguments([1, 2]);
 
         $this->assertFormat("TestNamespace\\<class>TestClass</class>-><function>test</function>(<argument>1</argument>, <argument>2</argument>)");
+    }
+
+    public function testFormatWithoutTagFormatter()
+    {
+        $formatter = new StackFrameCallTextFormatter();
+
+        $this->frame->setClassName("TestNamespace\\TestClass");
+        $this->frame->setType(StackFrame::TYPE_METHOD);
+        $this->frame->setFunctionName("test");
+        $this->frame->setArguments([1, 2]);
+
+        $this->assertEquals("TestNamespace\\TestClass->test(1, 2)", $formatter->format($this->frame));
     }
 }


### PR DESCRIPTION
Add a new renderer to the debug handler (see #4). It's used for requests with the `Accept: application/json` header. [Here](https://slashtrace.com/demo.json) is example output that corresponds to the error on the [demo page](https://slashtrace.com/demo.php). 