### PR TITLE
allow to push handlers

### DIFF
--- a/src/SlashTrace.php
+++ b/src/SlashTrace.php
@@ -65,7 +65,7 @@ class SlashTrace
         $this->handlers[] = $handler;
     }
 
-    public function pushHandler(EventHandler $handler)
+    public function prependHandler(EventHandler $handler)
     {
         $this->checkUniqueHandler($handler);
         array_unshift($this->handlers, $handler);

--- a/src/SlashTrace.php
+++ b/src/SlashTrace.php
@@ -65,6 +65,12 @@ class SlashTrace
         $this->handlers[] = $handler;
     }
 
+    public function pushHandler(EventHandler $handler)
+    {
+        $this->checkUniqueHandler($handler);
+        array_unshift($this->handlers, $handler);
+    }
+
     /**
      * Checks that a particular handler hasn't already been registered
      *

--- a/tests/SlashTraceTest.php
+++ b/tests/SlashTraceTest.php
@@ -64,15 +64,34 @@ class SlashTraceTest extends TestCase
 
     public function testCanAddHandlers()
     {
-        $handler = $this->createMock(EventHandler::class);
+        $handler1 = $this->createMock(EventHandler::class);
+        $handler2 = $this->createMock(EventHandler::class);
 
         /** @noinspection PhpParamsInspection */
-        $this->slashtrace->addHandler($handler);
+        $this->slashtrace->addHandler($handler1);
+        $this->slashtrace->addHandler($handler2);
 
         $handlers = $this->slashtrace->getHandlers();
 
-        $this->assertEquals(1, count($handlers));
-        $this->assertSame($handler, $handlers[0]);
+        $this->assertEquals(2, count($handlers));
+        $this->assertSame($handler1, $handlers[0]);
+        $this->assertSame($handler2, $handlers[1]);
+    }
+
+    public function testCanPushHandlers()
+    {
+        $handler1 = $this->createMock(EventHandler::class);
+        $handler2 = $this->createMock(EventHandler::class);
+
+        /** @noinspection PhpParamsInspection */
+        $this->slashtrace->pushHandler($handler1);
+        $this->slashtrace->pushHandler($handler2);
+
+        $handlers = $this->slashtrace->getHandlers();
+
+        $this->assertEquals(2, count($handlers));
+        $this->assertSame($handler2, $handlers[0]);
+        $this->assertSame($handler1, $handlers[1]);
     }
 
     public function testAddingTheSameHandlerTwiceRaisesException()

--- a/tests/SlashTraceTest.php
+++ b/tests/SlashTraceTest.php
@@ -78,14 +78,14 @@ class SlashTraceTest extends TestCase
         $this->assertSame($handler2, $handlers[1]);
     }
 
-    public function testCanPushHandlers()
+    public function testCanPrependHandlers()
     {
         $handler1 = $this->createMock(EventHandler::class);
         $handler2 = $this->createMock(EventHandler::class);
 
         /** @noinspection PhpParamsInspection */
-        $this->slashtrace->pushHandler($handler1);
-        $this->slashtrace->pushHandler($handler2);
+        $this->slashtrace->prependHandler($handler1);
+        $this->slashtrace->prependHandler($handler2);
 
         $handlers = $this->slashtrace->getHandlers();
 


### PR DESCRIPTION
This PR add a ->pushHandler() to the SlashTrace class. It allows to add handlers *before* the already registered handlers.