### PR TITLE
fix JsonSerializable::jsonSerialize() return type

### DIFF
--- a/src/Context/Breadcrumbs.php
+++ b/src/Context/Breadcrumbs.php
@@ -79,7 +79,7 @@ class Breadcrumbs implements JsonSerializable
         $this->crumbs = [];
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return $this->crumbs;
     }

--- a/src/Context/Breadcrumbs/Breadcrumb.php
+++ b/src/Context/Breadcrumbs/Breadcrumb.php
@@ -52,7 +52,7 @@ class Breadcrumb implements JsonSerializable
         return $this->dateTime;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "title" => $this->getTitle(),

--- a/src/Context/EventContext.php
+++ b/src/Context/EventContext.php
@@ -130,7 +130,7 @@ class EventContext implements JsonSerializable
         return !is_null($this->getRelease()) || !is_null($this->getUser());
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             "request"          => $this->getHTTPRequest(),

--- a/src/Context/User.php
+++ b/src/Context/User.php
@@ -67,7 +67,7 @@ class User implements JsonSerializable
         $this->name = $name;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             "id"    => $this->getId(),

--- a/src/Event.php
+++ b/src/Event.php
@@ -59,7 +59,7 @@ class Event implements JsonSerializable
         $this->context = $context;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "level"   => $this->getLevel(),

--- a/src/Exception/ExceptionData.php
+++ b/src/Exception/ExceptionData.php
@@ -52,7 +52,7 @@ class ExceptionData implements JsonSerializable
         $this->stackTrace = $stackTrace;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return array_filter([
             "type"       => $this->getType(),

--- a/src/Http/Request.php
+++ b/src/Http/Request.php
@@ -141,7 +141,7 @@ class Request implements JsonSerializable
         return null;
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         return [
             "url"     => $this->getUrl(),

--- a/src/StackTrace/StackFrame.php
+++ b/src/StackTrace/StackFrame.php
@@ -113,7 +113,7 @@ class StackFrame implements JsonSerializable
         return ltrim(substr($path, strlen($rootPath)), "/\\");
     }
 
-    public function jsonSerialize()
+    public function jsonSerialize(): mixed
     {
         $serializer = new Serializer();
         $callFormatter = new StackFrameCallTextFormatter();


### PR DESCRIPTION
fix for php >= 8.1

PHP Deprecated:  Return type of chillerlan\Settings\SettingsContainerAbstract::jsonSerialize() should either be compatible with JsonSerializable::jsonSerialize(): mixed, or the #[\ReturnTypeWillChange] attribute should be used to temporarily suppress the notice